### PR TITLE
Drill down support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "birst-react-embed",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,10 +43,13 @@
 		},
 		"testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(tsx?)$",
 		"moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json"],
-		"unmockedModulePathPatterns": [
-			"node_modules/react/",
-			"node_modules/enzyme/"
-		],
+		"unmockedModulePathPatterns": ["node_modules/react/", "node_modules/enzyme/"],
 		"snapshotSerializers": ["<rootDir>/node_modules/enzyme-to-json/serializer"]
+	},
+	"prettier": {
+		"useTabs": true,
+		"singleQuote": true,
+		"printWidth": 90,
+		"jsxBracketSameLine": true
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "birst-react-embed",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"main": "index.js",
 	"types": "index.d.ts",
 	"description": "Embed React-generated content in Birst dashboards",

--- a/src/birst/IDrillDown.ts
+++ b/src/birst/IDrillDown.ts
@@ -1,0 +1,5 @@
+export interface IDrillDown {
+	collection: string;
+	dashboard: string;
+	filters?: string[];
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
-export {connectToBirst} from './BirstComponent';
-export {embedInBirst} from './embedInBirst';
-export {IBqlResults} from './birst/IBqlResults';
-export {IBqlQuery} from './birst/IBqlQuery';
+export { connectToBirst } from './BirstComponent';
+export { embedInBirst } from './embedInBirst';
+export { IBqlResults } from './birst/IBqlResults';
+export { IBqlQuery } from './birst/IBqlQuery';
+export { IDrillDown } from './birst/IDrillDown';


### PR DESCRIPTION
Birst allows us to do some basic navigation from within custom dashboard content.  This change provides a way to use this from a connected component